### PR TITLE
Fix build with kernel 6.6

### DIFF
--- a/virtio_vmmci.c
+++ b/virtio_vmmci.c
@@ -89,11 +89,6 @@ static struct ctl_table drift_table[] = {
 	{ },
 };
 
-static struct ctl_table vmmci_table = {
-	.procname	= "vmmci",
-	.child		= drift_table,
-};
-
 /* Define our basic commands and structs for our device including the
  * virtio feature tables.
  */
@@ -282,7 +277,9 @@ static int vmmci_probe(struct virtio_device *vdev)
 
 	INIT_WORK(&vmmci->sync_work, sync_work_func);
 
-	vmmci_table_header = register_sysctl_table(&vmmci_table);
+	vmmci_table_header = register_sysctl("dev/vmmci", drift_table);
+	if (!vmmci_table_header)
+		return -ENOMEM;
 
 	log("started VMM Control Interface driver\n");
 	return 0;


### PR DESCRIPTION
The deprecated child node was replaced with an enum in commit 2f2665c13af (sysctl: replace child with an enumeration)

fixes: https://github.com/voutilad/virtio_vmmci/issues/15
ref: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=2f2665c13af4895b26761107c2f637c2f112d8e9kl
